### PR TITLE
既存のrefreshPeerList()をオンライン状態の取得とListのリフレッシュで分けた

### DIFF
--- a/app/src/main/java/com/the_mad_pillow/twitphone/adapters/ExpandableAdapter.java
+++ b/app/src/main/java/com/the_mad_pillow/twitphone/adapters/ExpandableAdapter.java
@@ -110,6 +110,7 @@ public class ExpandableAdapter extends BaseExpandableListAdapter {
         Glide.with(view).load(myUser.getUser().profileImageUrlHttps.replace("normal", "bigger")).into(imageView);
         nameText.setText(myUser.getUser().name);
         screenNameText.setText(activity.getString(R.string.screenName, myUser.getUser().screenName));
+
         like.setOnCheckedChangeListener((buttonView, isChecked) -> {
             if (isChecked) {
                 activity.getMyTwitter().addFavoriteUser(myUser);

--- a/app/src/main/java/com/the_mad_pillow/twitphone/others/MyPeer.java
+++ b/app/src/main/java/com/the_mad_pillow/twitphone/others/MyPeer.java
@@ -68,9 +68,9 @@ public class MyPeer {
     }
 
     /**
-     * Listのオンライン状態のリロード
+     * Listのオンライン状態の取得
      */
-    public void refreshPeerList() {
+    public void reloadOnlineStatus() {
         peer.listAllPeers(object -> {
             List<String> peerList = new ArrayList<>();
             for (int i = 0; i < ((JSONArray) object).length(); i++) {
@@ -84,13 +84,20 @@ public class MyPeer {
             for (MyUser user : activity.getMyTwitter().getFFList()) {
                 user.setOnline(peerList.contains(user.getUser().screenName));
             }
-            //Listの更新
-            activity.getMyTwitter().getOnlineList(true);
-            activity.getMyTwitter().getOtherList(true);
-            activity.runOnUiThread(() -> {
-                activity.getAdapter().notifyDataSetChanged();
-                activity.getSwipeRefreshLayout().setRefreshing(false);
-            });
+
+            refreshPeerList();
+        });
+    }
+
+    /**
+     * List更新
+     */
+    public void refreshPeerList(){
+        activity.getMyTwitter().getOnlineList(true);
+        activity.getMyTwitter().getOtherList(true);
+        activity.runOnUiThread(() -> {
+            activity.getAdapter().notifyDataSetChanged();
+            activity.getSwipeRefreshLayout().setRefreshing(false);
         });
     }
 


### PR DESCRIPTION
#46 fixed
お気に入り登録の度にオンライン状態の取得をサーバーと行い、その後Listのリフレッシュを行う状態になっていたので、根本のrefreshPeerList()をオンライン状態を取得する関数getOnlineStatus()とListをrefreshする関数refreshPeerList()に分割して、お気に入り登録時はrefreshPeerList()のみを使用しListの更新を行うようにした。